### PR TITLE
Update matrix for 2.5 branch version

### DIFF
--- a/.github/workflows/update-documentation.yaml
+++ b/.github/workflows/update-documentation.yaml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             matrix:
                 version:
-                    - { ref: '2.x', version: 'latest' }
+                    - { ref: '2.5', version: 'latest' }
                     - { ref: '2.4', version: '2.4' }
                     - { ref: '2.3', version: '2.3' }
                     - { ref: '2.2.19', version: '2.2' }


### PR DESCRIPTION
The branch 2.x was renamed to 2.5 to allow usage of `2.5.*@dev` in composer.json.